### PR TITLE
Add support for role sync for vanilla SSO

### DIFF
--- a/src/controllers/VanillaSSOController.php
+++ b/src/controllers/VanillaSSOController.php
@@ -22,6 +22,7 @@ class VanillaSSOController extends \BaseController
         $ssoUser->id = $user->id;
         $ssoUser->name = $user->username;
         $ssoUser->email = $user->email;
+        $ssoUser->roles = $user->roles;
         $ssoUser->profilepicture = "";
 
         $userInfo = $ssoUser->toArray();

--- a/src/models/SSOUser.php
+++ b/src/models/SSOUser.php
@@ -9,13 +9,15 @@ class SSOUser {
     public $id;
     public $name;
     public $email;
+    public $roles;
     public $profilepicture;
 
     function __construct()
     {
-        $this->email = null;
-        $this->id = null;
-        $this->name = null;
+        $this->email          = null;
+        $this->id             = null;
+        $this->name           = null;
+        $this->roles          = null;
         $this->profilepicture = "";
     }
 
@@ -25,8 +27,9 @@ class SSOUser {
     function toArray() {
         return array(
             "uniqueid" => $this->id,
-            "name" => $this->name,
-            "email" => $this->email,
+            "name"     => $this->name,
+            "email"    => $this->email,
+            "roles"    => $this->roles,
             "photourl" => $this->profilepicture
         );
     }


### PR DESCRIPTION
The vanilla Jsconnect plugin supports synchronizing roles. This adds the roles key to the SSOUser class and modifies the Controller to reflect the ability to pass roles. 
